### PR TITLE
Fix a typo in the guard clause

### DIFF
--- a/RocketReserver/DetailViewController.swift
+++ b/RocketReserver/DetailViewController.swift
@@ -84,7 +84,7 @@ class DetailViewController: UIViewController {
         guard
             let launchID = self.launchID,
             (forceReload || launchID != self.launch?.id) else {
-                // This is the launch we're alrady displaying, or the ID is nil.
+                // This is the launch we're already displaying, or the ID is nil.
                 return
         }
         


### PR DESCRIPTION
Fixes a typo in the `loadLaunchDetails()` function.

Similar to https://github.com/apollographql/apollo-ios/pull/1123