### PR TITLE
Wrap starter DetailView placeholder text in Optional()

### DIFF
--- a/starter/RocketReserver/DetailView.swift
+++ b/starter/RocketReserver/DetailView.swift
@@ -11,7 +11,7 @@ struct DetailView: View {
     
     var body: some View {
         VStack {
-            if let launch = "PLACEHOLDER" {
+            if let launch = Optional("PLACEHOLDER") {
                 HStack(spacing: 10) {
                     placeholderImg
                         .resizable()
@@ -19,17 +19,17 @@ struct DetailView: View {
                         .frame(width: 165, height: 165)
                     
                     VStack(alignment: .leading, spacing: 4) {
-                        if let missionName = "Mission Name" {
+                        if let missionName = Optional("Mission Name") {
                             Text(missionName)
                                 .font(.system(size: 24, weight: .bold))
                         }
                         
-                        if let rocketName = "Rocket Name" {
+                        if let rocketName = Optional("Rocket Name") {
                             Text("🚀 \(rocketName)")
                                 .font(.system(size: 18))
                         }
                         
-                        if let launchSite = "Launch Site" {
+                        if let launchSite = Optional("Launch Site") {
                             Text(launchSite)
                                 .font(.system(size: 14))
                         }


### PR DESCRIPTION
Since we instruct users to build and run the app early on, they might be thrown off by the `Initializer for conditional binding must have Optional type, not 'String'` message if we don't wrap these

See also: https://github.com/apollographql/apollo-ios/pull/3032