### PR TITLE
Base changes to prepare for Summit Workshop

### DIFF
--- a/final/RocketReserver.xcodeproj/project.pbxproj
+++ b/final/RocketReserver.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		66F96FE629FC070600713B80 /* NetworkInterceptorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F96FE529FC070600713B80 /* NetworkInterceptorProvider.swift */; };
 		66F96FE829FC0D7700713B80 /* View+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F96FE729FC0D7700713B80 /* View+Alert.swift */; };
 		66F96FEA29FC183200713B80 /* NotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F96FE929FC183200713B80 /* NotificationView.swift */; };
+		E67B2DF02C7D02BC0095602B /* UserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67B2DEF2C7D02BC0095602B /* UserView.swift */; };
+		E67B2DF22C7D03180095602B /* UserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67B2DF12C7D03180095602B /* UserViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +56,9 @@
 		66F96FE729FC0D7700713B80 /* View+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Alert.swift"; sourceTree = "<group>"; };
 		66F96FE929FC183200713B80 /* NotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationView.swift; sourceTree = "<group>"; };
 		66F96FEB29FC2BF400713B80 /* RocketReserverAPI */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = RocketReserverAPI; sourceTree = "<group>"; };
+		E67B2DEF2C7D02BC0095602B /* UserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserView.swift; sourceTree = "<group>"; };
+		E67B2DF12C7D03180095602B /* UserViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserViewModel.swift; sourceTree = "<group>"; };
+		E67B2DF32C7D27620095602B /* Me.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = Me.graphql; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +87,7 @@
 				66D7A53F2A056886009DDB89 /* TripsBooked.graphql */,
 				66D7A5402A056886009DDB89 /* LaunchList.graphql */,
 				66D7A5412A056886009DDB89 /* CancelTrip.graphql */,
+				E67B2DF32C7D27620095602B /* Me.graphql */,
 			);
 			path = graphql;
 			sourceTree = "<group>";
@@ -123,6 +129,8 @@
 				66F96FE929FC183200713B80 /* NotificationView.swift */,
 				66F96F9E29FAC0D700713B80 /* Assets.xcassets */,
 				66F96FA029FAC0D700713B80 /* Preview Content */,
+				E67B2DEF2C7D02BC0095602B /* UserView.swift */,
+				E67B2DF12C7D03180095602B /* UserViewModel.swift */,
 			);
 			path = RocketReserver;
 			sourceTree = "<group>";
@@ -245,6 +253,8 @@
 				66F96F9B29FAC0D600713B80 /* RocketReserverApp.swift in Sources */,
 				66F96FE229FB0A9600713B80 /* LoginViewModel.swift in Sources */,
 				66F96FE429FC069D00713B80 /* AuthorizationInterceptor.swift in Sources */,
+				E67B2DF22C7D03180095602B /* UserViewModel.swift in Sources */,
+				E67B2DF02C7D02BC0095602B /* UserView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/final/RocketReserver/DetailView.swift
+++ b/final/RocketReserver/DetailView.swift
@@ -6,7 +6,8 @@ struct DetailView: View {
     private let placeholderImg = Image("placeholder")
     
     @StateObject private var viewModel: DetailViewModel
-    
+    @State private var isShowingUser = false
+
     init(launchID: RocketReserverAPI.ID) {
         _viewModel = StateObject(wrappedValue: DetailViewModel(launchID: launchID))
     }
@@ -60,6 +61,16 @@ struct DetailView: View {
         .padding(10)
         .navigationTitle(viewModel.launch?.mission?.name ?? "")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            Button("User", systemImage: "person.circle") {
+                if !viewModel.isShowingLogin {
+                    self.isShowingUser.toggle()
+                }
+            }
+            .sheet(isPresented: $isShowingUser) {
+                UserView()
+            }
+        }
         .task {
             viewModel.loadLaunchDetails()
         }

--- a/final/RocketReserver/DetailView.swift
+++ b/final/RocketReserver/DetailView.swift
@@ -61,16 +61,6 @@ struct DetailView: View {
         .padding(10)
         .navigationTitle(viewModel.launch?.mission?.name ?? "")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            Button("User", systemImage: "person.circle") {
-                if !viewModel.isShowingLogin {
-                    self.isShowingUser.toggle()
-                }
-            }
-            .sheet(isPresented: $isShowingUser) {
-                UserView()
-            }
-        }
         .task {
             viewModel.loadLaunchDetails()
         }

--- a/final/RocketReserver/LaunchListView.swift
+++ b/final/RocketReserver/LaunchListView.swift
@@ -1,9 +1,12 @@
 import SwiftUI
+import KeychainSwift
 
 struct LaunchListView: View {
     
     @StateObject private var viewModel = LaunchListViewModel()
-    
+    @State private var isShowingLogin = false
+    @State private var isShowingUser = false
+
     var body: some View {
         NavigationStack {
             List {
@@ -26,11 +29,32 @@ struct LaunchListView: View {
                 viewModel.loadMoreLaunchesIfTheyExist()
             }
             .navigationTitle("Rocket Launches")
+            .toolbar {
+                Button("User", systemImage: "person.circle") {
+                    guard self.isLoggedIn() else {
+                        isShowingLogin = true
+                        return
+                    }
+
+                    self.isShowingUser.toggle()
+                }
+                .sheet(isPresented: $isShowingUser) {
+                    UserView()
+                }
+            }
+            .sheet(isPresented: $isShowingLogin) {
+                LoginView(isPresented: $isShowingLogin)
+            }
             .appAlert($viewModel.appAlert)
         }
         .notificationView(message: $viewModel.notificationMessage)
     }
-    
+
+    private func isLoggedIn() -> Bool {
+        let keychain = KeychainSwift()
+        return keychain.get(LoginView.loginKeychainKey) != nil
+    }
+
 }
 
 struct LaunchListView_Previews: PreviewProvider {

--- a/final/RocketReserver/LaunchListView.swift
+++ b/final/RocketReserver/LaunchListView.swift
@@ -9,7 +9,7 @@ struct LaunchListView: View {
             List {
                 ForEach(0..<viewModel.launches.count, id: \.self) { index in
                     NavigationLink(destination: DetailView(launchID: viewModel.launches[index].id)) {
-                        LaunchRow(launch: viewModel.launches[index])
+                        LaunchRow(launch: viewModel.launches[index].fragments.launchListDetail)
                     }
                 }
                 if viewModel.lastConnection?.hasMore != false {

--- a/final/RocketReserver/LaunchListView.swift
+++ b/final/RocketReserver/LaunchListView.swift
@@ -30,14 +30,16 @@ struct LaunchListView: View {
             }
             .navigationTitle("Rocket Launches")
             .toolbar {
-                Button("User", systemImage: "person.circle") {
+                Button(action: {
                     guard self.isLoggedIn() else {
                         isShowingLogin = true
                         return
                     }
 
                     self.isShowingUser.toggle()
-                }
+                }, label: {
+                    Image(systemName: "person.circle")
+                })
                 .sheet(isPresented: $isShowingUser) {
                     UserView()
                 }

--- a/final/RocketReserver/LaunchRow.swift
+++ b/final/RocketReserver/LaunchRow.swift
@@ -3,7 +3,7 @@ import SDWebImageSwiftUI
 import SwiftUI
 
 struct LaunchRow: View {
-    let launch: LaunchListQuery.Data.Launches.Launch
+    let launch: LaunchListDetail
     private let placeholderImg = Image("placeholder")
     
     var body: some View {

--- a/final/RocketReserver/UserView.swift
+++ b/final/RocketReserver/UserView.swift
@@ -18,6 +18,9 @@ struct UserView: View {
                         }
                     }
                 }
+                if (viewModel.trips?.count ?? 0) == 0 {
+                    Text("No trips booked")
+                }
             }
             .task {
                 viewModel.loadTrips()

--- a/final/RocketReserver/UserView.swift
+++ b/final/RocketReserver/UserView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct UserView: View {
+
+    @StateObject private var viewModel: UserViewModel
+
+    init() {
+        _viewModel = StateObject(wrappedValue: UserViewModel())
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if let trips = viewModel.trips {
+                    ForEach(0..<trips.count, id: \.self) { index in
+                        NavigationLink(destination: DetailView(launchID: trips[index].id)) {
+                            LaunchRow(launch: trips[index].fragments.launchListDetail)
+                        }
+                    }
+                }
+            }
+            .task {
+                viewModel.loadTrips()
+            }
+            .navigationTitle("Booked Trips")
+            .appAlert($viewModel.appAlert)
+        }
+        .presentationDragIndicator(.visible)
+    }
+}
+
+#Preview {
+    UserView()
+}

--- a/final/RocketReserver/UserViewModel.swift
+++ b/final/RocketReserver/UserViewModel.swift
@@ -1,0 +1,28 @@
+import Apollo
+import RocketReserverAPI
+import SwiftUI
+
+class UserViewModel: ObservableObject {
+
+    @Published var trips: [MeQuery.Data.Me.Trip]?
+    @Published var appAlert: AppAlert?
+
+    func loadTrips() {
+        Network.shared.apollo.fetch(query: MeQuery(), cachePolicy: .returnCacheDataAndFetch) { [weak self] result in
+            guard let self = self else {
+                return
+            }
+
+            switch result {
+            case .success(let graphQLResult):
+                self.trips = graphQLResult.data?.me?.trips.compactMap({ $0 })
+
+                if let errors = graphQLResult.errors {
+                    self.appAlert = .errors(errors: errors)
+                }
+            case .failure(let error):
+                self.appAlert = .errors(errors: [error])
+            }
+        }
+    }
+}

--- a/final/RocketReserverAPI/Sources/Fragments/LaunchListDetail.graphql.swift
+++ b/final/RocketReserverAPI/Sources/Fragments/LaunchListDetail.graphql.swift
@@ -1,0 +1,43 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public struct LaunchListDetail: RocketReserverAPI.SelectionSet, Fragment {
+  public static var fragmentDefinition: StaticString {
+    #"fragment LaunchListDetail on Launch { __typename id site mission { __typename name missionPatch(size: SMALL) } }"#
+  }
+
+  public let __data: DataDict
+  public init(_dataDict: DataDict) { __data = _dataDict }
+
+  public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.Launch }
+  public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
+    .field("id", RocketReserverAPI.ID.self),
+    .field("site", String?.self),
+    .field("mission", Mission?.self),
+  ] }
+
+  public var id: RocketReserverAPI.ID { __data["id"] }
+  public var site: String? { __data["site"] }
+  public var mission: Mission? { __data["mission"] }
+
+  /// Mission
+  ///
+  /// Parent Type: `Mission`
+  public struct Mission: RocketReserverAPI.SelectionSet {
+    public let __data: DataDict
+    public init(_dataDict: DataDict) { __data = _dataDict }
+
+    public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.Mission }
+    public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
+      .field("name", String?.self),
+      .field("missionPatch", String?.self, arguments: ["size": "SMALL"]),
+    ] }
+
+    public var name: String? { __data["name"] }
+    public var missionPatch: String? { __data["missionPatch"] }
+  }
+}

--- a/final/RocketReserverAPI/Sources/Operations/Mutations/BookTripMutation.graphql.swift
+++ b/final/RocketReserverAPI/Sources/Operations/Mutations/BookTripMutation.graphql.swift
@@ -22,7 +22,7 @@ public class BookTripMutation: GraphQLMutation {
     public let __data: DataDict
     public init(_dataDict: DataDict) { __data = _dataDict }
 
-    public static var __parentType: ApolloAPI.ParentType { RocketReserverAPI.Objects.Mutation }
+    public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.Mutation }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("bookTrips", BookTrips.self, arguments: ["launchIds": [.variable("id")]]),
     ] }
@@ -36,7 +36,7 @@ public class BookTripMutation: GraphQLMutation {
       public let __data: DataDict
       public init(_dataDict: DataDict) { __data = _dataDict }
 
-      public static var __parentType: ApolloAPI.ParentType { RocketReserverAPI.Objects.TripUpdateResponse }
+      public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.TripUpdateResponse }
       public static var __selections: [ApolloAPI.Selection] { [
         .field("__typename", String.self),
         .field("success", Bool.self),

--- a/final/RocketReserverAPI/Sources/Operations/Mutations/CancelTripMutation.graphql.swift
+++ b/final/RocketReserverAPI/Sources/Operations/Mutations/CancelTripMutation.graphql.swift
@@ -22,7 +22,7 @@ public class CancelTripMutation: GraphQLMutation {
     public let __data: DataDict
     public init(_dataDict: DataDict) { __data = _dataDict }
 
-    public static var __parentType: ApolloAPI.ParentType { RocketReserverAPI.Objects.Mutation }
+    public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.Mutation }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("cancelTrip", CancelTrip.self, arguments: ["launchId": .variable("launchId")]),
     ] }
@@ -36,7 +36,7 @@ public class CancelTripMutation: GraphQLMutation {
       public let __data: DataDict
       public init(_dataDict: DataDict) { __data = _dataDict }
 
-      public static var __parentType: ApolloAPI.ParentType { RocketReserverAPI.Objects.TripUpdateResponse }
+      public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.TripUpdateResponse }
       public static var __selections: [ApolloAPI.Selection] { [
         .field("__typename", String.self),
         .field("success", Bool.self),

--- a/final/RocketReserverAPI/Sources/Operations/Mutations/LoginMutation.graphql.swift
+++ b/final/RocketReserverAPI/Sources/Operations/Mutations/LoginMutation.graphql.swift
@@ -22,7 +22,7 @@ public class LoginMutation: GraphQLMutation {
     public let __data: DataDict
     public init(_dataDict: DataDict) { __data = _dataDict }
 
-    public static var __parentType: ApolloAPI.ParentType { RocketReserverAPI.Objects.Mutation }
+    public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.Mutation }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("login", Login?.self, arguments: ["email": .variable("email")]),
     ] }
@@ -36,7 +36,7 @@ public class LoginMutation: GraphQLMutation {
       public let __data: DataDict
       public init(_dataDict: DataDict) { __data = _dataDict }
 
-      public static var __parentType: ApolloAPI.ParentType { RocketReserverAPI.Objects.User }
+      public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.User }
       public static var __selections: [ApolloAPI.Selection] { [
         .field("__typename", String.self),
         .field("token", String?.self),

--- a/final/RocketReserverAPI/Sources/Operations/Queries/LaunchDetailsQuery.graphql.swift
+++ b/final/RocketReserverAPI/Sources/Operations/Queries/LaunchDetailsQuery.graphql.swift
@@ -22,7 +22,7 @@ public class LaunchDetailsQuery: GraphQLQuery {
     public let __data: DataDict
     public init(_dataDict: DataDict) { __data = _dataDict }
 
-    public static var __parentType: ApolloAPI.ParentType { RocketReserverAPI.Objects.Query }
+    public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("launch", Launch?.self, arguments: ["id": .variable("launchId")]),
     ] }
@@ -36,7 +36,7 @@ public class LaunchDetailsQuery: GraphQLQuery {
       public let __data: DataDict
       public init(_dataDict: DataDict) { __data = _dataDict }
 
-      public static var __parentType: ApolloAPI.ParentType { RocketReserverAPI.Objects.Launch }
+      public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.Launch }
       public static var __selections: [ApolloAPI.Selection] { [
         .field("__typename", String.self),
         .field("id", RocketReserverAPI.ID.self),
@@ -59,7 +59,7 @@ public class LaunchDetailsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(_dataDict: DataDict) { __data = _dataDict }
 
-        public static var __parentType: ApolloAPI.ParentType { RocketReserverAPI.Objects.Mission }
+        public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.Mission }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("__typename", String.self),
           .field("name", String?.self),
@@ -77,7 +77,7 @@ public class LaunchDetailsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(_dataDict: DataDict) { __data = _dataDict }
 
-        public static var __parentType: ApolloAPI.ParentType { RocketReserverAPI.Objects.Rocket }
+        public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.Rocket }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("__typename", String.self),
           .field("name", String?.self),

--- a/final/RocketReserverAPI/Sources/Operations/Queries/LaunchListQuery.graphql.swift
+++ b/final/RocketReserverAPI/Sources/Operations/Queries/LaunchListQuery.graphql.swift
@@ -22,7 +22,7 @@ public class LaunchListQuery: GraphQLQuery {
     public let __data: DataDict
     public init(_dataDict: DataDict) { __data = _dataDict }
 
-    public static var __parentType: ApolloAPI.ParentType { RocketReserverAPI.Objects.Query }
+    public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("launches", Launches.self, arguments: ["after": .variable("cursor")]),
     ] }
@@ -36,7 +36,7 @@ public class LaunchListQuery: GraphQLQuery {
       public let __data: DataDict
       public init(_dataDict: DataDict) { __data = _dataDict }
 
-      public static var __parentType: ApolloAPI.ParentType { RocketReserverAPI.Objects.LaunchConnection }
+      public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.LaunchConnection }
       public static var __selections: [ApolloAPI.Selection] { [
         .field("__typename", String.self),
         .field("cursor", String.self),
@@ -55,7 +55,7 @@ public class LaunchListQuery: GraphQLQuery {
         public let __data: DataDict
         public init(_dataDict: DataDict) { __data = _dataDict }
 
-        public static var __parentType: ApolloAPI.ParentType { RocketReserverAPI.Objects.Launch }
+        public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.Launch }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("__typename", String.self),
           .field("id", RocketReserverAPI.ID.self),

--- a/final/RocketReserverAPI/Sources/Operations/Queries/LaunchListQuery.graphql.swift
+++ b/final/RocketReserverAPI/Sources/Operations/Queries/LaunchListQuery.graphql.swift
@@ -7,7 +7,8 @@ public class LaunchListQuery: GraphQLQuery {
   public static let operationName: String = "LaunchList"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"query LaunchList($cursor: String) { launches(after: $cursor) { __typename cursor hasMore launches { __typename id site mission { __typename name missionPatch(size: SMALL) } } } }"#
+      #"query LaunchList($cursor: String) { launches(after: $cursor) { __typename cursor hasMore launches { __typename ...LaunchListDetail } } }"#,
+      fragments: [LaunchListDetail.self]
     ))
 
   public var cursor: GraphQLNullable<String>
@@ -58,32 +59,21 @@ public class LaunchListQuery: GraphQLQuery {
         public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.Launch }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("__typename", String.self),
-          .field("id", RocketReserverAPI.ID.self),
-          .field("site", String?.self),
-          .field("mission", Mission?.self),
+          .fragment(LaunchListDetail.self),
         ] }
 
         public var id: RocketReserverAPI.ID { __data["id"] }
         public var site: String? { __data["site"] }
         public var mission: Mission? { __data["mission"] }
 
-        /// Launches.Launch.Mission
-        ///
-        /// Parent Type: `Mission`
-        public struct Mission: RocketReserverAPI.SelectionSet {
+        public struct Fragments: FragmentContainer {
           public let __data: DataDict
           public init(_dataDict: DataDict) { __data = _dataDict }
 
-          public static var __parentType: ApolloAPI.ParentType { RocketReserverAPI.Objects.Mission }
-          public static var __selections: [ApolloAPI.Selection] { [
-            .field("__typename", String.self),
-            .field("name", String?.self),
-            .field("missionPatch", String?.self, arguments: ["size": "SMALL"]),
-          ] }
-
-          public var name: String? { __data["name"] }
-          public var missionPatch: String? { __data["missionPatch"] }
+          public var launchListDetail: LaunchListDetail { _toFragment() }
         }
+
+        public typealias Mission = LaunchListDetail.Mission
       }
     }
   }

--- a/final/RocketReserverAPI/Sources/Operations/Queries/MeQuery.graphql.swift
+++ b/final/RocketReserverAPI/Sources/Operations/Queries/MeQuery.graphql.swift
@@ -1,0 +1,72 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public class MeQuery: GraphQLQuery {
+  public static let operationName: String = "Me"
+  public static let operationDocument: ApolloAPI.OperationDocument = .init(
+    definition: .init(
+      #"query Me { me { __typename trips { __typename ...LaunchListDetail isBooked } } }"#,
+      fragments: [LaunchListDetail.self]
+    ))
+
+  public init() {}
+
+  public struct Data: RocketReserverAPI.SelectionSet {
+    public let __data: DataDict
+    public init(_dataDict: DataDict) { __data = _dataDict }
+
+    public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.Query }
+    public static var __selections: [ApolloAPI.Selection] { [
+      .field("me", Me?.self),
+    ] }
+
+    public var me: Me? { __data["me"] }
+
+    /// Me
+    ///
+    /// Parent Type: `User`
+    public struct Me: RocketReserverAPI.SelectionSet {
+      public let __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.User }
+      public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
+        .field("trips", [Trip?].self),
+      ] }
+
+      public var trips: [Trip?] { __data["trips"] }
+
+      /// Me.Trip
+      ///
+      /// Parent Type: `Launch`
+      public struct Trip: RocketReserverAPI.SelectionSet {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.Launch }
+        public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
+          .field("isBooked", Bool.self),
+          .fragment(LaunchListDetail.self),
+        ] }
+
+        public var isBooked: Bool { __data["isBooked"] }
+        public var id: RocketReserverAPI.ID { __data["id"] }
+        public var site: String? { __data["site"] }
+        public var mission: Mission? { __data["mission"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var launchListDetail: LaunchListDetail { _toFragment() }
+        }
+
+        public typealias Mission = LaunchListDetail.Mission
+      }
+    }
+  }
+}

--- a/final/RocketReserverAPI/Sources/Operations/Subscriptions/TripsBookedSubscription.graphql.swift
+++ b/final/RocketReserverAPI/Sources/Operations/Subscriptions/TripsBookedSubscription.graphql.swift
@@ -16,7 +16,7 @@ public class TripsBookedSubscription: GraphQLSubscription {
     public let __data: DataDict
     public init(_dataDict: DataDict) { __data = _dataDict }
 
-    public static var __parentType: ApolloAPI.ParentType { RocketReserverAPI.Objects.Subscription }
+    public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.Subscription }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("tripsBooked", Int?.self),
     ] }

--- a/final/RocketReserverAPI/Sources/Schema/CustomScalars/ID.swift
+++ b/final/RocketReserverAPI/Sources/Schema/CustomScalars/ID.swift
@@ -1,0 +1,11 @@
+// @generated
+// This file was automatically generated and can be edited to
+// implement advanced custom scalar functionality.
+//
+// Any changes to this file will not be overwritten by future
+// code generation execution.
+
+import ApolloAPI
+
+/// The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
+public typealias ID = String

--- a/final/RocketReserverAPI/Sources/Schema/SchemaMetadata.graphql.swift
+++ b/final/RocketReserverAPI/Sources/Schema/SchemaMetadata.graphql.swift
@@ -3,8 +3,6 @@
 
 import ApolloAPI
 
-public typealias ID = String
-
 public protocol SelectionSet: ApolloAPI.SelectionSet & ApolloAPI.RootSelectionSet
 where Schema == RocketReserverAPI.SchemaMetadata {}
 
@@ -18,15 +16,15 @@ public protocol MutableInlineFragment: ApolloAPI.MutableSelectionSet & ApolloAPI
 where Schema == RocketReserverAPI.SchemaMetadata {}
 
 public enum SchemaMetadata: ApolloAPI.SchemaMetadata {
-  public static let configuration: ApolloAPI.SchemaConfiguration.Type = SchemaConfiguration.self
+  public static let configuration: any ApolloAPI.SchemaConfiguration.Type = SchemaConfiguration.self
 
   public static func objectType(forTypename typename: String) -> ApolloAPI.Object? {
     switch typename {
-    case "Mutation": return RocketReserverAPI.Objects.Mutation
-    case "User": return RocketReserverAPI.Objects.User
     case "Query": return RocketReserverAPI.Objects.Query
+    case "User": return RocketReserverAPI.Objects.User
     case "Launch": return RocketReserverAPI.Objects.Launch
     case "Mission": return RocketReserverAPI.Objects.Mission
+    case "Mutation": return RocketReserverAPI.Objects.Mutation
     case "Rocket": return RocketReserverAPI.Objects.Rocket
     case "TripUpdateResponse": return RocketReserverAPI.Objects.TripUpdateResponse
     case "Subscription": return RocketReserverAPI.Objects.Subscription

--- a/final/graphql/LaunchList.graphql
+++ b/final/graphql/LaunchList.graphql
@@ -3,12 +3,16 @@ query LaunchList($cursor: String) {
     cursor
     hasMore
     launches {
-      id
-      site
-      mission {
-        name
-        missionPatch(size: SMALL)
-      }
+      ... LaunchListDetail
     }
+  }
+}
+
+fragment LaunchListDetail on Launch {
+  id
+  site
+  mission {
+    name
+    missionPatch(size: SMALL)
   }
 }

--- a/final/graphql/Me.graphql
+++ b/final/graphql/Me.graphql
@@ -1,0 +1,8 @@
+query Me {
+  me {
+    trips {
+      ... LaunchListDetail
+      isBooked
+    }
+  }
+}


### PR DESCRIPTION
These are some changes that I think should be applied to the tutorial to prepare for the Summit Workshop parts:
1. Regenerates the models to get the latest codegen output
2. Refactored to use a fragment for the launch list (used in the Me query)
3. Adds a user query and list view to show a list of the user's booked trips (this is modified in part 2 of the workshop but I felt building this query and list view shouldn't be in part 2 though)