### PR TITLE
Summit Workshop - Part 2

### DIFF
--- a/final/RocketReserver.xcodeproj/project.pbxproj
+++ b/final/RocketReserver.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		66F96FE629FC070600713B80 /* NetworkInterceptorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F96FE529FC070600713B80 /* NetworkInterceptorProvider.swift */; };
 		66F96FE829FC0D7700713B80 /* View+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F96FE729FC0D7700713B80 /* View+Alert.swift */; };
 		66F96FEA29FC183200713B80 /* NotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F96FE929FC183200713B80 /* NotificationView.swift */; };
+		E6072AF32C7FEEEB00ED4E49 /* TripsBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6072AF22C7FEEEB00ED4E49 /* TripsBadgeView.swift */; };
+		E61F95BD2C8264C300A55230 /* TripsBadgeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61F95BC2C8264C300A55230 /* TripsBadgeViewModel.swift */; };
 		E67B2DF02C7D02BC0095602B /* UserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67B2DEF2C7D02BC0095602B /* UserView.swift */; };
 		E67B2DF22C7D03180095602B /* UserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67B2DF12C7D03180095602B /* UserViewModel.swift */; };
 /* End PBXBuildFile section */
@@ -56,6 +58,8 @@
 		66F96FE729FC0D7700713B80 /* View+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Alert.swift"; sourceTree = "<group>"; };
 		66F96FE929FC183200713B80 /* NotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationView.swift; sourceTree = "<group>"; };
 		66F96FEB29FC2BF400713B80 /* RocketReserverAPI */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = RocketReserverAPI; sourceTree = "<group>"; };
+		E6072AF22C7FEEEB00ED4E49 /* TripsBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripsBadgeView.swift; sourceTree = "<group>"; };
+		E61F95BC2C8264C300A55230 /* TripsBadgeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripsBadgeViewModel.swift; sourceTree = "<group>"; };
 		E67B2DEF2C7D02BC0095602B /* UserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserView.swift; sourceTree = "<group>"; };
 		E67B2DF12C7D03180095602B /* UserViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserViewModel.swift; sourceTree = "<group>"; };
 		E67B2DF32C7D27620095602B /* Me.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = Me.graphql; sourceTree = "<group>"; };
@@ -131,6 +135,8 @@
 				66F96FA029FAC0D700713B80 /* Preview Content */,
 				E67B2DEF2C7D02BC0095602B /* UserView.swift */,
 				E67B2DF12C7D03180095602B /* UserViewModel.swift */,
+				E6072AF22C7FEEEB00ED4E49 /* TripsBadgeView.swift */,
+				E61F95BC2C8264C300A55230 /* TripsBadgeViewModel.swift */,
 			);
 			path = RocketReserver;
 			sourceTree = "<group>";
@@ -253,8 +259,10 @@
 				66F96F9B29FAC0D600713B80 /* RocketReserverApp.swift in Sources */,
 				66F96FE229FB0A9600713B80 /* LoginViewModel.swift in Sources */,
 				66F96FE429FC069D00713B80 /* AuthorizationInterceptor.swift in Sources */,
+				E61F95BD2C8264C300A55230 /* TripsBadgeViewModel.swift in Sources */,
 				E67B2DF22C7D03180095602B /* UserViewModel.swift in Sources */,
 				E67B2DF02C7D02BC0095602B /* UserView.swift in Sources */,
+				E6072AF32C7FEEEB00ED4E49 /* TripsBadgeView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/final/RocketReserver/DetailView.swift
+++ b/final/RocketReserver/DetailView.swift
@@ -61,6 +61,15 @@ struct DetailView: View {
         .padding(10)
         .navigationTitle(viewModel.launch?.mission?.name ?? "")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            Button(action: { }, label: {
+                Image(systemName: "person.circle")
+                .overlay(
+                    TripBadgeView()
+                )
+            })
+            .disabled(true)
+        }
         .task {
             viewModel.loadLaunchDetails()
         }

--- a/final/RocketReserver/DetailViewModel.swift
+++ b/final/RocketReserver/DetailViewModel.swift
@@ -69,14 +69,18 @@ class DetailViewModel: ObservableObject {
                         self.appAlert = .basic(title: "Success!",
                                                message: bookingResult.message ?? "Trip booked successfully")
 
-                        Network.shared.apollo.store.withinReadWriteTransaction { transaction in
-                            let cacheMutation = MeTripsLocalCacheMutation()
+                        if let bookedTrip = bookingResult.launches?.first ?? nil {
+                            Network.shared.apollo.store.withinReadWriteTransaction { transaction in
+                                let cacheMutation = MeTripsLocalCacheMutation()
 
-                            try transaction.update(cacheMutation) { data in
-                                data.me?.trips.append(.init(
-                                    isBooked: true,
-                                    id: id
-                                ))
+                                try transaction.update(cacheMutation) { data in
+                                    data.me?.trips.append(.init(
+                                        isBooked: bookedTrip.isBooked,
+                                        id: bookedTrip.id,
+                                        site: bookedTrip.site,
+                                        mission: bookedTrip.mission
+                                    ))
+                                }
                             }
                         }
                     } else {

--- a/final/RocketReserver/DetailViewModel.swift
+++ b/final/RocketReserver/DetailViewModel.swift
@@ -106,6 +106,14 @@ class DetailViewModel: ObservableObject {
                     if cancelResult.success {
                         self.appAlert = .basic(title: "Trip cancelled",
                                                message: cancelResult.message ?? "Your trip has been officially cancelled")
+
+                        Network.shared.apollo.store.withinReadWriteTransaction { transaction in
+                            let cacheMutation = MeTripsLocalCacheMutation()
+
+                            try transaction.update(cacheMutation) { data in
+                                data.me?.trips.removeAll(where: { $0?.id == id })
+                            }
+                        }
                     } else {
                         self.appAlert = .basic(title: "Could not cancel trip",
                                                message: cancelResult.message ?? "Unknown failure.")

--- a/final/RocketReserver/DetailViewModel.swift
+++ b/final/RocketReserver/DetailViewModel.swift
@@ -68,6 +68,17 @@ class DetailViewModel: ObservableObject {
                     if bookingResult.success {
                         self.appAlert = .basic(title: "Success!",
                                                message: bookingResult.message ?? "Trip booked successfully")
+
+                        Network.shared.apollo.store.withinReadWriteTransaction { transaction in
+                            let cacheMutation = MeTripsLocalCacheMutation()
+
+                            try transaction.update(cacheMutation) { data in
+                                data.me?.trips.append(.init(
+                                    isBooked: true,
+                                    id: id
+                                ))
+                            }
+                        }
                     } else {
                         self.appAlert = .basic(title: "Could not book trip",
                                                message: bookingResult.message ?? "Unknown failure")

--- a/final/RocketReserver/LaunchListView.swift
+++ b/final/RocketReserver/LaunchListView.swift
@@ -39,6 +39,9 @@ struct LaunchListView: View {
                     self.isShowingUser.toggle()
                 }, label: {
                     Image(systemName: "person.circle")
+                    .overlay(
+                        TripBadgeView()
+                    )
                 })
                 .sheet(isPresented: $isShowingUser) {
                     UserView()

--- a/final/RocketReserver/TripsBadgeView.swift
+++ b/final/RocketReserver/TripsBadgeView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct TripBadgeView : View {
+
+    private let size = 16.0
+    private let x = 20.0
+    private let y = 0.0
+
+    @StateObject private var viewModel = TripsBadgeViewModel()
+
+    var body: some View {
+        ZStack {
+            Capsule()
+            .fill(.red)
+            .frame(width: size * widthMultplier(), height: size, alignment: .topTrailing)
+            .position(x: x, y: y)
+
+            Text("\(viewModel.count)")
+            .foregroundColor(.white)
+            .font(Font.caption)
+            .position(x: x, y: y)
+        }
+        .task {
+            viewModel.loadUserTrips()
+        }
+    }
+
+    func widthMultplier() -> Double {
+        let value = viewModel.count
+
+        if value < 10 {
+            return 1.0
+        } else if value < 100 {
+            return 1.5
+        } else {
+            return 2.0
+        }
+    }
+}

--- a/final/RocketReserver/TripsBadgeViewModel.swift
+++ b/final/RocketReserver/TripsBadgeViewModel.swift
@@ -5,16 +5,17 @@ import SwiftUI
 
 class TripsBadgeViewModel: ObservableObject {
 
+    private var watcher: GraphQLQueryWatcher<MeQuery>?
+
     @Published var count: Int = 0
     @Published var appAlert: AppAlert?
 
     func loadUserTrips() {
-        guard isLoggedIn() else {
-            count = 0
+        guard isLoggedIn(), watcher == nil else {
             return
         }
 
-        _ = Network.shared.apollo.watch(
+        watcher = Network.shared.apollo.watch(
             query: MeQuery(), cachePolicy: .returnCacheDataAndFetch
         ) { [weak self] result in
             guard let self = self else {
@@ -32,6 +33,10 @@ class TripsBadgeViewModel: ObservableObject {
                 self.appAlert = .errors(errors: [error])
             }
         }
+    }
+
+    deinit {
+        watcher?.cancel()
     }
 
     private func isLoggedIn() -> Bool {

--- a/final/RocketReserver/TripsBadgeViewModel.swift
+++ b/final/RocketReserver/TripsBadgeViewModel.swift
@@ -1,0 +1,42 @@
+import Apollo
+import KeychainSwift
+import RocketReserverAPI
+import SwiftUI
+
+class TripsBadgeViewModel: ObservableObject {
+
+    @Published var count: Int = 0
+    @Published var appAlert: AppAlert?
+
+    func loadUserTrips() {
+        guard isLoggedIn() else {
+            count = 0
+            return
+        }
+
+        _ = Network.shared.apollo.watch(
+            query: MeQuery(), cachePolicy: .returnCacheDataAndFetch
+        ) { [weak self] result in
+            guard let self = self else {
+                return
+            }
+
+            switch result {
+            case.success(let graphQLResult):
+                count = graphQLResult.data?.me?.trips.count ?? 0
+
+                if let errors = graphQLResult.errors {
+                    self.appAlert = .errors(errors: errors)
+                }
+            case .failure(let error):
+                self.appAlert = .errors(errors: [error])
+            }
+        }
+    }
+
+    private func isLoggedIn() -> Bool {
+        let keychain = KeychainSwift()
+        return keychain.get(LoginView.loginKeychainKey) != nil
+    }
+
+}

--- a/final/RocketReserverAPI/Sources/LocalCacheMutations/MeTripsLocalCacheMutation.graphql.swift
+++ b/final/RocketReserverAPI/Sources/LocalCacheMutations/MeTripsLocalCacheMutation.graphql.swift
@@ -1,0 +1,137 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public class MeTripsLocalCacheMutation: LocalCacheMutation {
+  public static let operationType: GraphQLOperationType = .query
+
+  public init() {}
+
+  public struct Data: RocketReserverAPI.MutableSelectionSet {
+    public var __data: DataDict
+    public init(_dataDict: DataDict) { __data = _dataDict }
+
+    public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.Query }
+    public static var __selections: [ApolloAPI.Selection] { [
+      .field("me", Me?.self),
+    ] }
+
+    public var me: Me? {
+      get { __data["me"] }
+      set { __data["me"] = newValue }
+    }
+
+    public init(
+      me: Me? = nil
+    ) {
+      self.init(_dataDict: DataDict(
+        data: [
+          "__typename": RocketReserverAPI.Objects.Query.typename,
+          "me": me._fieldData,
+        ],
+        fulfilledFragments: [
+          ObjectIdentifier(MeTripsLocalCacheMutation.Data.self)
+        ]
+      ))
+    }
+
+    /// Me
+    ///
+    /// Parent Type: `User`
+    public struct Me: RocketReserverAPI.MutableSelectionSet {
+      public var __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.User }
+      public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
+        .field("trips", [Trip?].self),
+      ] }
+
+      public var trips: [Trip?] {
+        get { __data["trips"] }
+        set { __data["trips"] = newValue }
+      }
+
+      public init(
+        trips: [Trip?]
+      ) {
+        self.init(_dataDict: DataDict(
+          data: [
+            "__typename": RocketReserverAPI.Objects.User.typename,
+            "trips": trips._fieldData,
+          ],
+          fulfilledFragments: [
+            ObjectIdentifier(MeTripsLocalCacheMutation.Data.Me.self)
+          ]
+        ))
+      }
+
+      /// Me.Trip
+      ///
+      /// Parent Type: `Launch`
+      public struct Trip: RocketReserverAPI.MutableSelectionSet {
+        public var __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public static var __parentType: any ApolloAPI.ParentType { RocketReserverAPI.Objects.Launch }
+        public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
+          .field("isBooked", Bool.self),
+          .fragment(LaunchListDetail.self),
+        ] }
+
+        public var isBooked: Bool {
+          get { __data["isBooked"] }
+          set { __data["isBooked"] = newValue }
+        }
+        public var id: RocketReserverAPI.ID {
+          get { __data["id"] }
+          set { __data["id"] = newValue }
+        }
+        public var site: String? {
+          get { __data["site"] }
+          set { __data["site"] = newValue }
+        }
+        public var mission: Mission? {
+          get { __data["mission"] }
+          set { __data["mission"] = newValue }
+        }
+
+        public struct Fragments: FragmentContainer {
+          public var __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var launchListDetail: LaunchListDetail {
+            get { _toFragment() }
+            _modify { var f = launchListDetail; yield &f; __data = f.__data }
+          }
+        }
+
+        public init(
+          isBooked: Bool,
+          id: RocketReserverAPI.ID,
+          site: String? = nil,
+          mission: Mission? = nil
+        ) {
+          self.init(_dataDict: DataDict(
+            data: [
+              "__typename": RocketReserverAPI.Objects.Launch.typename,
+              "isBooked": isBooked,
+              "id": id,
+              "site": site,
+              "mission": mission._fieldData,
+            ],
+            fulfilledFragments: [
+              ObjectIdentifier(MeTripsLocalCacheMutation.Data.Me.Trip.self),
+              ObjectIdentifier(LaunchListDetail.self)
+            ]
+          ))
+        }
+
+        public typealias Mission = LaunchListDetail.Mission
+      }
+    }
+  }
+}

--- a/final/graphql/Me.graphql
+++ b/final/graphql/Me.graphql
@@ -6,3 +6,12 @@ query Me {
     }
   }
 }
+
+query MeTrips @apollo_client_ios_localCacheMutation {
+  me {
+    trips {
+      ... LaunchListDetail
+      isBooked
+    }
+  }
+}


### PR DESCRIPTION
Part 2 - Make the user trips badge automatically update when a trip is booked or cancelled.

1. Add navigation bar badge for user booked trips count (reuse existing icon + badge).
2. Add query watcher to watch list of booked trips (me query).
3. Update the cache after successful book/cancel trip mutation response.
4. Define local cache mutation to update user list of booked trips.
